### PR TITLE
Extend functionality for needs of  `snapshot`

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         dependency-extras: ["-E logging", ""]
 
     steps:
       - uses: actions/checkout@v3
       - name: Install poetry
-        run: pipx install "poetry==1.5.1"
+        run: pipx install "poetry==1.8.3"
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install poetry
-      run: pipx install 'poetry==1.5.1'
+      run: pipx install 'poetry==1.8.3'
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ strict = true
 module = "tests.*"
 allow_incomplete_defs = true
 allow_untyped_defs = true
+disable_error_code = [
+    "possibly-undefined"
+]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -102,10 +102,15 @@ def test_get_mounted_devices_raises_on_unknown_device() -> None:
 
 
 def test_get_mounted_devices_includes_correct_mountpoints(mounted_directories) -> None:
-    src, dest = mounted_directories
-    assert any(
-        dest in mount_points for mount_points in sdm.get_mounted_devices().values()
-    )
+    _, dest = mounted_directories
+    all_mounts = sdm.get_mounted_devices()
+    for dest_set in all_mounts.values():
+        if dest in dest_set:
+            mount_options = dest_set[dest]
+            break
+    else:
+        raise AssertionError(f"Expected mount point {dest} not found.")
+    assert "rw" in mount_options
 
 
 def test_get_mounted_devices_includes_root() -> None:

--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -14,10 +14,6 @@ from hypothesis import strategies as st
 import storage_device_managers as sdm
 
 
-def in_docker_container() -> bool:
-    return Path("/.dockerenv").exists()
-
-
 def get_random_filename() -> str:
     with NamedTemporaryFile() as named_file:
         return named_file.name
@@ -25,109 +21,6 @@ def get_random_filename() -> str:
 
 class MyCustomTestException(Exception):
     pass
-
-
-def test_mounted_device_without_compression(btrfs_device) -> None:
-    with sdm.mounted_device(btrfs_device) as md:
-        assert md.exists()
-        assert md.is_dir()
-        assert sdm.is_mounted(btrfs_device)
-        assert md in sdm.get_mounted_devices()[str(btrfs_device)]
-    assert not md.exists()
-    assert not sdm.is_mounted(btrfs_device)
-    assert str(btrfs_device) not in sdm.get_mounted_devices()
-
-
-def test_mounted_device_with_compression(btrfs_device) -> None:
-    with sdm.mounted_device(btrfs_device, sdm.ValidCompressions.ZSTD9) as md:
-        assert md.exists()
-        assert md.is_dir()
-        assert sdm.is_mounted(btrfs_device)
-        assert md in sdm.get_mounted_devices()[str(btrfs_device)]
-    assert not md.exists()
-    assert not sdm.is_mounted(btrfs_device)
-    assert str(btrfs_device) not in sdm.get_mounted_devices()
-
-
-def test_mounted_device_takes_over_already_mounted_device(btrfs_device) -> None:
-    compression = sdm.ValidCompressions.LZO
-    with TemporaryDirectory() as td:
-        sdm.mount_btrfs_device(btrfs_device, Path(td), compression)
-        with sdm.mounted_device(btrfs_device, compression) as md:
-            assert sdm.is_mounted(btrfs_device)
-            assert md in sdm.get_mounted_devices()[str(btrfs_device)]
-        assert not sdm.is_mounted(btrfs_device)
-
-
-@pytest.mark.skipif(
-    in_docker_container(), reason="Root file system may be missing in Docker container."
-)
-def test_mounted_device_fails_on_not_unmountable_device() -> None:
-    def get_root_device() -> Path:
-        for device, mount_points in sdm.get_mounted_devices().items():
-            if Path("/") in mount_points:
-                return Path(device)
-        raise ValueError("No device mounted on / was found.")
-
-    root = get_root_device()
-    with pytest.raises(sdm.UnmountError):
-        with sdm.mounted_device(root):
-            pass
-
-
-def test_mounted_device_unmounts_in_case_of_exception(btrfs_device) -> None:
-    with pytest.raises(MyCustomTestException):
-        with sdm.mounted_device(btrfs_device, sdm.ValidCompressions.ZLIB1) as md:
-            # That the device is mounted properly is guaranteed by a test
-            # above.
-            raise MyCustomTestException
-    assert not md.exists()
-    assert not sdm.is_mounted(btrfs_device)
-    assert str(btrfs_device) not in sdm.get_mounted_devices()
-
-
-@pytest.mark.parametrize("device", sdm.get_mounted_devices())
-def test_is_mounted_detects(device: Path) -> None:
-    assert sdm.is_mounted(device)
-
-
-def test_is_mounted_rejects() -> None:
-    with TemporaryDirectory() as tempd:
-        assert not sdm.is_mounted(Path(tempd))
-
-
-def test_get_mounted_devices_raises_on_unknown_device() -> None:
-    with pytest.raises(KeyError):
-        sdm.get_mounted_devices()["unknown-device"]
-
-
-def test_get_mounted_devices_includes_correct_mountpoints(mounted_directories) -> None:
-    _, dest = mounted_directories
-    all_mounts = sdm.get_mounted_devices()
-    for dest_set in all_mounts.values():
-        if dest in dest_set:
-            mount_options = dest_set[dest]
-            break
-    else:
-        raise AssertionError(f"Expected mount point {dest} not found.")
-    assert "rw" in mount_options
-
-
-def test_get_mounted_devices_includes_root() -> None:
-    assert any(Path("/") in dest_set for dest_set in sdm.get_mounted_devices().values())
-
-
-def test_unmount_device(btrfs_device) -> None:
-    with TemporaryDirectory() as mountpoint:
-        sdm.mount_btrfs_device(btrfs_device, Path(mountpoint))
-        sdm.unmount_device(btrfs_device)
-        assert not sdm.is_mounted(btrfs_device)
-
-
-def test_unmount_device_raises_unmounterror() -> None:
-    with TemporaryDirectory() as mountpoint:
-        with pytest.raises(sdm.UnmountError):
-            sdm.unmount_device(Path(mountpoint))
 
 
 def test_open_encrypted_device_raises_devicedecryptionerror() -> None:

--- a/tests/test_get_mounted_devices.py
+++ b/tests/test_get_mounted_devices.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import storage_device_managers as sdm
+
+
+def test_get_mounted_devices_raises_on_unknown_device() -> None:
+    with pytest.raises(KeyError):
+        sdm.get_mounted_devices()["unknown-device"]
+
+
+def test_get_mounted_devices_includes_correct_mountpoints(mounted_directories) -> None:
+    _, dest = mounted_directories
+    all_mounts = sdm.get_mounted_devices()
+    for dest_set in all_mounts.values():
+        if dest in dest_set:
+            mount_options = dest_set[dest]
+            break
+    else:
+        raise AssertionError(f"Expected mount point {dest} not found.")
+    assert "rw" in mount_options
+
+
+def test_get_mounted_devices_includes_root() -> None:
+    assert any(Path("/") in dest_set for dest_set in sdm.get_mounted_devices().values())

--- a/tests/test_mount_unmount.py
+++ b/tests/test_mount_unmount.py
@@ -16,19 +16,9 @@ class MyCustomTestException(Exception):
     pass
 
 
-def test_mounted_device_without_compression(btrfs_device) -> None:
-    with sdm.mounted_device(btrfs_device) as md:
-        assert md.exists()
-        assert md.is_dir()
-        assert sdm.is_mounted(btrfs_device)
-        assert md in sdm.get_mounted_devices()[str(btrfs_device)]
-    assert not md.exists()
-    assert not sdm.is_mounted(btrfs_device)
-    assert str(btrfs_device) not in sdm.get_mounted_devices()
-
-
-def test_mounted_device_with_compression(btrfs_device) -> None:
-    with sdm.mounted_device(btrfs_device, sdm.ValidCompressions.ZSTD9) as md:
+@pytest.mark.parametrize("args", [[], [sdm.ValidCompressions.ZSTD9]])
+def test_mounted_device_without_compression(btrfs_device, args) -> None:
+    with sdm.mounted_device(btrfs_device, *args) as md:
         assert md.exists()
         assert md.is_dir()
         assert sdm.is_mounted(btrfs_device)

--- a/tests/test_mount_unmount.py
+++ b/tests/test_mount_unmount.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+import storage_device_managers as sdm
+
+
+def in_docker_container() -> bool:
+    return Path("/.dockerenv").exists()
+
+
+class MyCustomTestException(Exception):
+    pass
+
+
+def test_mounted_device_without_compression(btrfs_device) -> None:
+    with sdm.mounted_device(btrfs_device) as md:
+        assert md.exists()
+        assert md.is_dir()
+        assert sdm.is_mounted(btrfs_device)
+        assert md in sdm.get_mounted_devices()[str(btrfs_device)]
+    assert not md.exists()
+    assert not sdm.is_mounted(btrfs_device)
+    assert str(btrfs_device) not in sdm.get_mounted_devices()
+
+
+def test_mounted_device_with_compression(btrfs_device) -> None:
+    with sdm.mounted_device(btrfs_device, sdm.ValidCompressions.ZSTD9) as md:
+        assert md.exists()
+        assert md.is_dir()
+        assert sdm.is_mounted(btrfs_device)
+        assert md in sdm.get_mounted_devices()[str(btrfs_device)]
+    assert not md.exists()
+    assert not sdm.is_mounted(btrfs_device)
+    assert str(btrfs_device) not in sdm.get_mounted_devices()
+
+
+def test_mounted_device_takes_over_already_mounted_device(btrfs_device) -> None:
+    compression = sdm.ValidCompressions.LZO
+    with TemporaryDirectory() as td:
+        sdm.mount_btrfs_device(btrfs_device, Path(td), compression)
+        with sdm.mounted_device(btrfs_device, compression) as md:
+            assert sdm.is_mounted(btrfs_device)
+            assert md in sdm.get_mounted_devices()[str(btrfs_device)]
+        assert not sdm.is_mounted(btrfs_device)
+
+
+@pytest.mark.skipif(
+    in_docker_container(), reason="Root file system may be missing in Docker container."
+)
+def test_mounted_device_fails_on_not_unmountable_device() -> None:
+    def get_root_device() -> Path:
+        for device, mount_points in sdm.get_mounted_devices().items():
+            if Path("/") in mount_points:
+                return Path(device)
+        raise ValueError("No device mounted on / was found.")
+
+    root = get_root_device()
+    with pytest.raises(sdm.UnmountError):
+        with sdm.mounted_device(root):
+            pass
+
+
+def test_mounted_device_unmounts_in_case_of_exception(btrfs_device) -> None:
+    with pytest.raises(MyCustomTestException):
+        with sdm.mounted_device(btrfs_device, sdm.ValidCompressions.ZLIB1) as md:
+            # That the device is mounted properly is guaranteed by a test
+            # above.
+            raise MyCustomTestException
+    assert not md.exists()
+    assert not sdm.is_mounted(btrfs_device)
+    assert str(btrfs_device) not in sdm.get_mounted_devices()
+
+
+@pytest.mark.parametrize("device", sdm.get_mounted_devices())
+def test_is_mounted_detects(device: Path) -> None:
+    assert sdm.is_mounted(device)
+
+
+def test_is_mounted_rejects() -> None:
+    with TemporaryDirectory() as tempd:
+        assert not sdm.is_mounted(Path(tempd))
+
+
+def test_unmount_device(btrfs_device) -> None:
+    with TemporaryDirectory() as mountpoint:
+        sdm.mount_btrfs_device(btrfs_device, Path(mountpoint))
+        sdm.unmount_device(btrfs_device)
+        assert not sdm.is_mounted(btrfs_device)
+
+
+def test_unmount_device_raises_unmounterror() -> None:
+    with TemporaryDirectory() as mountpoint:
+        with pytest.raises(sdm.UnmountError):
+            sdm.unmount_device(Path(mountpoint))

--- a/tests/test_mount_unmount.py
+++ b/tests/test_mount_unmount.py
@@ -16,9 +16,18 @@ class MyCustomTestException(Exception):
     pass
 
 
-@pytest.mark.parametrize("args", [[], [sdm.ValidCompressions.ZSTD9]])
-def test_mounted_device_without_compression(btrfs_device, args) -> None:
-    with sdm.mounted_device(btrfs_device, *args) as md:
+@pytest.mark.parametrize(
+    "args,kwargs",
+    [
+        ([], {}),
+        ([sdm.ValidCompressions.ZSTD9], {}),
+        ([sdm.ValidCompressions.ZLIB5, 0], {}),
+        ([], {"subvol": "@"}),
+        ([], {"subvol": 0}),
+    ],
+)
+def test_mounted_device(btrfs_device, args, kwargs) -> None:
+    with sdm.mounted_device(btrfs_device, *args, **kwargs) as md:
         assert md.exists()
         assert md.is_dir()
         assert sdm.is_mounted(btrfs_device)


### PR DESCRIPTION
An external project,
[root-subvol-snapshot](https://github.com/MaxG87/root-subvol-snapshot),
will require some extended functionality. It will need the ability
to specify subvolumes and to inspect the mount options to detect
previously mounted devices.